### PR TITLE
I18n

### DIFF
--- a/lib/date_validator.rb
+++ b/lib/date_validator.rb
@@ -23,7 +23,7 @@ module ActiveModel
         return if options[:allow_nil] && value.nil?
 
         unless value
-          record.errors.add(attr_name, I18n.t("errors.messages.not_a_date"), :value => value, :default => options[:message])
+          record.errors.add(attr_name, :not_a_date, options)
           return
         end
   
@@ -46,8 +46,7 @@ module ActiveModel
           end
          
           unless is_time?(option_value) && value.to_i.send(CHECKS[option], option_value.to_i)
-            error_msg = options[:message] || I18n.t("errors.messages.#{option}", :value => original_option_value)
-            record.errors.add(attr_name, error_msg, :default => options[:message], :value => original_value, :date => original_option_value)
+            record.errors.add(attr_name, option, options.merge(:value => original_value, :date => original_option_value))
           end
         end
       end
@@ -59,3 +58,6 @@ module ActiveModel
     end
   end
 end
+
+require 'active_support/i18n'
+I18n.load_path += Dir[File.expand_path(File.join(File.dirname(__FILE__), '../locales', '*.yml')).to_s]

--- a/locales/ca.yml
+++ b/locales/ca.yml
@@ -1,11 +1,11 @@
 # Sample localization file for English. Add more files in this directory for other locales.
 # See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
-en:
+ca:
   errors:
     messages:
       not_a_date: "is not a date"
-      after: "must be after %{value}"
-      after_or_equal_to: "must be after or equal to %{value}"
-      before: "must be before %{value}"
-      before_or_equal_to: "must be before or equal to %{value}"
+      after: "must be after %{date}"
+      after_or_equal_to: "must be after or equal to %{date}"
+      before: "must be before %{date}"
+      before_or_equal_to: "must be before or equal to %{date}"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,8 +1,8 @@
-ca:
+en:
   errors:
     messages:
-      not_a_date: "no és una data"
-      after: "ha de ser posterior a %{value}"
-      after_or_equal_to: "ha de ser posterior o igual a %{value}"
-      before: "ha de ser abans de %{value}"
-      before_or_equal_to: "ha de ser abans o igual a %{value}"
+      not_a_date: "is not a date"
+      after: "must be after %{date}"
+      after_or_equal_to: "must be after or equal to %{date}"
+      before: "must be before %{date}"
+      before_or_equal_to: "must be before or equal to %{date}"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -2,7 +2,7 @@ es:
   errors:
     messages:
       not_a_date: "no es una fecha"
-      after: "tiene que ser posterior a %{value}"
-      after_or_equal_to: "tiene que ser posterior o igual a %{value}"
-      before: "tiene que ser antes de %{value}"
-      before_or_equal_to: "tiene que ser antes o igual a %{value}"
+      after: "tiene que ser posterior a %{date}"
+      after_or_equal_to: "tiene que ser posterior o igual a %{date}"
+      before: "tiene que ser antes de %{date}"
+      before_or_equal_to: "tiene que ser antes o igual a %{date}"

--- a/spec/date_validator_spec.rb
+++ b/spec/date_validator_spec.rb
@@ -68,6 +68,15 @@ describe "DateValidator" do
           model.errors[:expiration_date].should == ["must be after Christmas"]
         end
 
+        it "allows custom validation message to be handled by I18n" do
+          custom_message = 'Custom Date Message'
+          I18n.backend.store_translations('en', {:errors => {:messages => {:not_a_date => custom_message}}})
+          TestRecord.validates :expiration_date, :date => true
+          model = TestRecord.new(nil)
+          model.should_not be_valid
+          model.errors[:expiration_date].should == [custom_message]
+        end
+
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,6 @@ require 'active_model'
 require 'date_validator'
 require 'rspec'
 
-I18n.load_path += Dir[File.join('locales', '*.{rb,yml}')]
-
 class TestRecord
   include ActiveModel::Validations
   attr_accessor :expiration_date


### PR DESCRIPTION
Made some tweaks to allow the messages to be overridden by the Rails application using the gem without explicitly calling :message => ''.  This falls in line with the standard ActiveModel validations.

I also corrected a few errors in the default translation files (ca: was listed in both ca.yml and en.yml, etc), and added autoloading of the translations to date_validator.rb, so the translations are automatically available.
