### PR TITLE
Bump activemodel dependency to 3.0 or 3.1

### DIFF
--- a/date_validator.gemspec
+++ b/date_validator.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "date_validator"
 
-  s.add_runtime_dependency 'activemodel', '~>3.0.0'
+  s.add_runtime_dependency 'activemodel', ['>= 3.0.0', '< 3.2.0']
 
   s.add_development_dependency 'rspec', '~> 2.5.0'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
In order to use this gem with Rails 3.1 I'm bumping the dependency to accept rails 3.0 and 3.1
