### PR TITLE
Relax gemspec dependencies to support Rails 3.2

### DIFF
--- a/date_validator.gemspec
+++ b/date_validator.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "date_validator"
 
-  s.add_runtime_dependency 'activemodel', ['>= 3.0.0', '< 3.2.0']
+  s.add_runtime_dependency 'activemodel', ['>= 3.0.0', '< 3.3.0']
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'activesupport', ['>= 3.0.0', '< 3.2.0']
+  s.add_development_dependency 'activesupport', ['>= 3.0.0', '< 3.3.0']
   s.add_development_dependency 'tzinfo', '~> 0.3.0'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
I ran the tests against Rails 3.2, and all passed.  Does this gemspec change seem reasonable to you?
