### PR TITLE
Consider expressions that cannot be type cast to be invalid

### DIFF
--- a/test/date_validator_test.rb
+++ b/test/date_validator_test.rb
@@ -131,6 +131,22 @@ module ActiveModel
 
         TestRecord.new(Time.now).valid?.must_equal false
       end
+
+      describe "with type cast attributes" do
+        before do
+          TestRecord.send(:define_method, :expiration_date_before_type_cast, lambda { 'last year' })
+        end
+
+        it "should detect invalid date expressions when nil is allowed" do
+          TestRecord.validates(:expiration_date, :date => true, :allow_nil => true)
+          TestRecord.new(nil).valid?.must_equal false
+        end
+
+        it "should detect invalid date expressions when blank is allowed" do
+          TestRecord.validates(:expiration_date, :date => true, :allow_blank => true)
+          TestRecord.new(nil).valid?.must_equal false
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Useful for ActiveRecord models where string a value is assigned to using  `Model#attributes=`. ActiveRecord will try to type cast the string to a date. When the type cast fails because the string cannot be parsed, it assigns nil to the attribute.

Prior to this change if you specified `:allow_nil => true` or `:allow_blank => true` it would incorrectly consider the attribute to be valid. I added some logic to check the value before type cast, taking care to preserve backwards compatibility.

It should resolve issue https://github.com/codegram/date_validator/issues/25. Hope it helps.
