### PR TITLE
Fixed Russian translation

### DIFF
--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -1,7 +1,7 @@
 ru:
   errors:
     messages:
-      not_a_date: "неверный формат"
+      not_a_date: "не является датой"
       after: "должна быть позднее чем %{date}"
       after_or_equal_to: "должна равняться или быть позднее чем %{date}"
       before: "должна быть ранее чем %{date}"


### PR DESCRIPTION
Fixed Russian translation.
"is not a date" instead of "has wrong format"

Thanks for the great gem!
