### PR TITLE
Change hashes to 1.9.3+ format and remove trailing whitespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ active_model_version = ENV['ACTIVE_MODEL_VERSION'] || 'default'
 active_model_opts =
   case active_model_version
   when 'master'
-    {github: 'rails/rails'}
+    { github: 'rails/rails' }
   when 'default'
     '~> 3'
   else

--- a/Rakefile
+++ b/Rakefile
@@ -41,8 +41,8 @@ begin
     repo.branch("#{source_branch}").checkout
   end
 
-  task :doc => [:docs]
+  task doc: [:docs]
 rescue LoadError
 end
 
-task :default => :test
+task default: :test

--- a/Readme.md
+++ b/Readme.md
@@ -11,15 +11,15 @@ $ gem install date_validator
 And I mean simple. In your model:
 
 ```ruby
-validates :expiration_date, :date => true
+validates :expiration_date, date: true
 ```
 
 or with some options, such as:
 
 ```ruby
 validates :expiration_date,
-          :date => {:after => Proc.new { Time.now },
-                    :before => Proc.new { Time.now + 1.year } }
+          date: { after: Proc.new { Time.now },
+                  before: Proc.new { Time.now + 1.year } }
 # Using Proc.new prevents production cache issues
 ```
 
@@ -29,7 +29,7 @@ a Symbol instead of a block:
 ```ruby
 # Ensure the expiration date is after the packaging date
 validates :expiration_date,
-          :date => {:after => :packaging_date}
+          date: { after: :packaging_date }
 ```
 
 For now the available options you can use are `:after`, `:before`,
@@ -39,20 +39,20 @@ If you want to specify a custom message, you can do so in the options hash:
 
 ```ruby
 validates :start_date,
-  :date => {:after => Proc.new { Date.today }, :message => 'must be after today'},
-  :on => :create
+  date: { after: Proc.new { Date.today }, message: 'must be after today' },
+  on: :create
 ```
 
-Pretty much self-explanatory! :) 
+Pretty much self-explanatory! :)
 
 If you want to make sure an attribute is before/after another attribute, use:
 
 ```ruby
-validates :start_date, :date => {:before => :end_date }
+validates :start_date, date: { before: :end_date }
 ```
 
 ## Note on Patches/Pull Requests
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a

--- a/lib/active_model/validations/date_validator.rb
+++ b/lib/active_model/validations/date_validator.rb
@@ -13,13 +13,13 @@ module ActiveModel
     class DateValidator < ActiveModel::EachValidator
 
       # Implemented checks and their associated operators.
-      CHECKS = { :after => :>, :after_or_equal_to => :>=,
-                :before => :<, :before_or_equal_to => :<=}.freeze
+      CHECKS = { after: :>,  after_or_equal_to: :>=,
+                before: :<, before_or_equal_to: :<= }.freeze
 
       # Call `#initialize` on the superclass, adding a default
-      # `:allow_nil => false` option.
+      # `allow_nil: false` option.
       def initialize(options)
-        super(options.reverse_merge(:allow_nil => false))
+        super(options.reverse_merge(allow_nil: false))
       end
 
       # Validates the arguments passed to the validator.
@@ -65,29 +65,29 @@ module ActiveModel
           record.errors.add(attr_name, :not_a_date, options)
           return
         end
-  
+
         options.slice(*CHECKS.keys).each do |option, option_value|
           option_value = option_value.call(record) if option_value.is_a?(Proc)
           option_value = record.send(option_value) if option_value.is_a?(Symbol)
-       
+
           original_value = value
           original_option_value = option_value
 
           # To enable to_i conversion, these types must be converted to Datetimes
           if defined?(ActiveSupport::TimeWithZone)
-            option_value = option_value.to_datetime if option_value.is_a?(ActiveSupport::TimeWithZone) 
-            value = value.to_datetime if value.is_a?(ActiveSupport::TimeWithZone)  
+            option_value = option_value.to_datetime if option_value.is_a?(ActiveSupport::TimeWithZone)
+            value = value.to_datetime if value.is_a?(ActiveSupport::TimeWithZone)
           end
 
           if defined?(Date)
-            option_value = option_value.to_datetime if option_value.is_a?(Date) 
-            value = value.to_datetime if value.is_a?(Date)  
+            option_value = option_value.to_datetime if option_value.is_a?(Date)
+            value = value.to_datetime if value.is_a?(Date)
           end
-         
+
           unless is_time?(option_value) && value.to_i.send(CHECKS[option], option_value.to_i)
             record.errors.add(attr_name, option, options.merge(
-                :value => original_value,
-                :date  => (I18n.localize(original_option_value) rescue original_option_value)
+                value: original_value,
+                date:  (I18n.localize(original_option_value) rescue original_option_value)
             ))
           end
         end
@@ -104,8 +104,8 @@ module ActiveModel
       # Validates whether the value of the specified attribute is a validate Date
       #
       #   class Person < ActiveRecord::Base
-      #     validates_date_of :payment_date, :after => :packaging_date
-      #     validates_date_of :expiration_date, :before => Proc.new { Time.now }
+      #     validates_date_of :payment_date, after: :packaging_date
+      #     validates_date_of :expiration_date, before: Proc.new { Time.now }
       #   end
       #
       # Configuration options:

--- a/lib/date_validator.rb
+++ b/lib/date_validator.rb
@@ -5,8 +5,8 @@ require 'active_support/i18n'
 #
 # @example
 #    validates :expiration_date,
-#              :date => {:after => Proc.new { Time.now },
-#                        :before => Proc.new { Time.now + 1.year } }
+#              date: { after: Proc.new { Time.now },
+#                      before: Proc.new { Time.now + 1.year } }
 #    # Using Proc.new prevents production cache issues
 #
 module DateValidator

--- a/test/date_validator_test.rb
+++ b/test/date_validator_test.rb
@@ -12,7 +12,7 @@ module ActiveModel
       it "checks validity of the arguments" do
         [3, "foo", 1..6].each do |wrong_argument|
           proc {
-            TestRecord.validates(:expiration_date, :date => {:before => wrong_argument})
+            TestRecord.validates(:expiration_date, date: { before: wrong_argument })
           }.must_raise(ArgumentError, ":before must be a time, a date, a time_with_zone, a symbol or a proc")
         end
       end
@@ -20,7 +20,7 @@ module ActiveModel
       it "complains when no options are provided" do
         I18n.backend.reload!
         TestRecord.validates :expiration_date,
-                             :date => {:before => Time.now}
+                             date: { before: Time.now }
 
         model = TestRecord.new(nil)
         model.valid?.must_equal false
@@ -29,7 +29,7 @@ module ActiveModel
 
       it "works with helper methods" do
         time = Time.now
-        TestRecord.validates_date_of :expiration_date, :before => time
+        TestRecord.validates_date_of :expiration_date, before: time
         model = TestRecord.new(time + 20000)
         model.valid?.must_equal false
       end
@@ -42,15 +42,15 @@ module ActiveModel
               now = Time.now.to_datetime
 
               model_date = case check
-                when :after then must_be == :valid ? now + 21000 : now - 1
-                when :before then must_be == :valid ? now - 21000 : now + 1
-                when :after_or_equal_to then must_be == :valid ? now : now - 21000
+                when :after              then must_be == :valid ? now + 21000 : now - 1
+                when :before             then must_be == :valid ? now - 21000 : now + 1
+                when :after_or_equal_to  then must_be == :valid ? now : now - 21000
                 when :before_or_equal_to then must_be == :valid ? now : now + 21000
               end
 
               it "ensures that an attribute is #{must_be} when #{must_be == :valid ? 'respecting' : 'offending' } the #{check} check" do
                 TestRecord.validates :expiration_date,
-                                     :date => {:"#{check}" => now}
+                                     date: {:"#{check}" => now}
 
                 model = TestRecord.new(model_date)
                 must_be == :valid ? model.valid?.must_equal(true) : model.valid?.must_equal(false)
@@ -59,7 +59,7 @@ module ActiveModel
               if _context == 'when value does not match validation requirements'
                 it "yields a default error message indicating that value must be #{check} validation requirements" do
                   TestRecord.validates :expiration_date,
-                                       :date => {:"#{check}" => now}
+                                       date: {:"#{check}" => now}
 
                   model = TestRecord.new(model_date)
                   model.valid?.must_equal false
@@ -73,8 +73,8 @@ module ActiveModel
 
             it "allows for a custom validation message" do
               TestRecord.validates :expiration_date,
-                                   :date => {:before_or_equal_to => now,
-                                             :message => 'must be after Christmas'}
+                                   date: { before_or_equal_to: now,
+                                           message: 'must be after Christmas' }
 
               model = TestRecord.new(now + 21000)
               model.valid?.must_equal false
@@ -83,9 +83,9 @@ module ActiveModel
 
             it "allows custom validation message to be handled by I18n" do
               custom_message = 'Custom Date Message'
-              I18n.backend.store_translations('en', {:errors => {:messages => {:not_a_date => custom_message}}})
+              I18n.backend.store_translations('en', { errors: { messages: { not_a_date: custom_message }}})
 
-              TestRecord.validates :expiration_date, :date => true
+              TestRecord.validates :expiration_date, date: true
 
               model = TestRecord.new(nil)
               model.valid?.must_equal false
@@ -104,22 +104,22 @@ module ActiveModel
         it "accepts a #{type} as an argument to a check" do
           case type
             when :proc then
-              TestRecord.validates(:expiration_date, :date => {:after => Proc.new{Time.now + 21000}}).must_be_kind_of Hash
+              TestRecord.validates(:expiration_date, date: { after: Proc.new {Time.now + 21000} }).must_be_kind_of Hash
             when :symbol then
               TestRecord.send(:define_method, :min_date, lambda { Time.now + 21000 })
-              TestRecord.validates(:expiration_date, :date => {:after => :min_date}).must_be_kind_of Hash
+              TestRecord.validates(:expiration_date, date: { after: :min_date }).must_be_kind_of Hash
             when :date then
-              TestRecord.validates(:expiration_date, :date => {:after => Time.now.to_date}).must_be_kind_of Hash
+              TestRecord.validates(:expiration_date, date: { after: Time.now.to_date }).must_be_kind_of Hash
             when :time_with_zone then
               Time.zone = "Hawaii"
-              TestRecord.validates(:expiration_date, :date => {:before => Time.zone.parse((Time.now + 21000).to_s)}).must_be_kind_of Hash
+              TestRecord.validates(:expiration_date, date: { before: Time.zone.parse((Time.now + 21000).to_s) }).must_be_kind_of Hash
           end
         end
       end
 
       it "gracefully handles an unexpected result from a proc argument evaluation" do
         TestRecord.validates :expiration_date,
-                             :date => {:after => Proc.new{ nil }}
+                             date: { after: Proc.new { nil } }
 
         TestRecord.new(Time.now).valid?.must_equal false
       end
@@ -127,7 +127,7 @@ module ActiveModel
       it "gracefully handles an unexpected result from a symbol argument evaluation" do
         TestRecord.send(:define_method, :min_date, lambda { nil })
         TestRecord.validates :expiration_date,
-                             :date => {:after => :min_date}
+                             date: { after: :min_date }
 
         TestRecord.new(Time.now).valid?.must_equal false
       end
@@ -138,12 +138,12 @@ module ActiveModel
         end
 
         it "should detect invalid date expressions when nil is allowed" do
-          TestRecord.validates(:expiration_date, :date => true, :allow_nil => true)
+          TestRecord.validates(:expiration_date, date: true, allow_nil: true)
           TestRecord.new(nil).valid?.must_equal false
         end
 
         it "should detect invalid date expressions when blank is allowed" do
-          TestRecord.validates(:expiration_date, :date => true, :allow_blank => true)
+          TestRecord.validates(:expiration_date, date: true, allow_blank: true)
           TestRecord.new(nil).valid?.must_equal false
         end
       end


### PR DESCRIPTION
I updated all the hashes to Ruby 1.9.3+ format since Ruby 1.9.2 is no longer used for tests.
