### PR TITLE
Add simple equality test for two dates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ validates :expiration_date,
 ```
 
 For now the available options you can use are `:after`, `:before`,
-`:after_or_equal_to` and `:before_or_equal_to`.
+`:after_or_equal_to`, `:before_or_equal_to` and `:equal_to`.
 
 If you want to specify a custom message, you can do so in the options hash:
 

--- a/lib/active_model/validations/date_validator.rb
+++ b/lib/active_model/validations/date_validator.rb
@@ -14,7 +14,9 @@ module ActiveModel
 
       # Implemented checks and their associated operators.
       CHECKS = { after: :>,  after_or_equal_to: :>=,
-                before: :<, before_or_equal_to: :<= }.freeze
+                before: :<, before_or_equal_to: :<=,
+                equal_to: :==
+      }.freeze
 
       # Call `#initialize` on the superclass, adding a default
       # `allow_nil: false` option.
@@ -113,6 +115,7 @@ module ActiveModel
       # * <tt>:before</tt> - check that a Date is before the specified one.
       # * <tt>:after_or_equal_to</tt> - check that a Date is after or equal to the specified one.
       # * <tt>:before_or_equal_to</tt> - check that a Date is before or equal to the specified one.
+      # * <tt>:equal_to</tt> - check that a Date is equal to the specified one.
       def validates_date_of(*attr_names)
         validates_with DateValidator, _merge_attributes(attr_names)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,3 +6,4 @@ en:
       after_or_equal_to: "must be after or equal to %{date}"
       before: "must be before %{date}"
       before_or_equal_to: "must be before or equal to %{date}"
+      equal_to: "must be equal to %{date}"

--- a/test/date_validator_test.rb
+++ b/test/date_validator_test.rb
@@ -38,7 +38,7 @@ module ActiveModel
         _context = must_be == :valid ? 'when value validates correctly' : 'when value does not match validation requirements'
 
         describe _context do
-          [:after, :before, :after_or_equal_to, :before_or_equal_to].each do |check|
+          [:after, :before, :after_or_equal_to, :before_or_equal_to, :equal_to].each do |check|
               now = Time.now.to_datetime
 
               model_date = case check
@@ -46,6 +46,7 @@ module ActiveModel
                 when :before             then must_be == :valid ? now - 21000 : now + 1
                 when :after_or_equal_to  then must_be == :valid ? now : now - 21000
                 when :before_or_equal_to then must_be == :valid ? now : now + 21000
+                when :equal_to           then must_be == :valid ? now : now + 21000
               end
 
               it "ensures that an attribute is #{must_be} when #{must_be == :valid ? 'respecting' : 'offending' } the #{check} check" do


### PR DESCRIPTION
In some cases I need to check if two dates are equal. I noticed that `date_validator` did most of the hard work of normalizing the two dates, but it didn't have this simple equality validator so I added it.

Let me know if you'd like me to change anything.

Note: I only updated the english locale.
