### PR TITLE
Fix test - require active_support first

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ begin; require 'turn'; rescue LoadError; end
 gem 'minitest'
 require 'minitest/autorun'
 
+require 'active_support'
 require 'active_support/core_ext'
 require 'active_support/time' # For testing Date and TimeWithZone objects
 


### PR DESCRIPTION
According to https://github.com/rails/rails/issues/14664 this fixes tests.

Otherwise this happens:
/usr/bin/ruby19 -I"lib:test" -I"/usr/lib64/ruby/gems/1.9.1/gems/rake-10.3.2/lib" "/usr/lib64/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb" "test/date_validator_test.rb" 
/usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
        from /usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
        from /usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/number_helper.rb:1:in `<top (required)>'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/core_ext/numeric/conversions.rb:2:in `<top (required)>'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/core_ext/numeric.rb:3:in `<top (required)>'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
        from /usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/core_ext.rb:1:in `each'
        from /usr/lib64/ruby/gems/1.9.1/gems/activesupport-4.1.6/lib/active_support/core_ext.rb:1:in `<top (required)>'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:118:in `require'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:118:in `rescue in require'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:124:in `require'
        from /var/tmp/portage/dev-ruby/date_validator-0.7.1/work/ruby19/date_validator-0.7.1/test/test_helper.rb:14:in `<top (required)>'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /var/tmp/portage/dev-ruby/date_validator-0.7.1/work/ruby19/date_validator-0.7.1/test/date_validator_test.rb:1:in `<top (required)>'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:53:in `require'
        from /usr/lib64/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:15:in `block in <main>'
        from /usr/lib64/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:4:in `select'
        from /usr/lib64/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib:test" -I"/usr/lib64/ruby/gems/1.9.1/gems/rake-10.3.2/lib" "/usr/lib64/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_test_loader.rb" "test/date_validator_test.rb" ]