### PR TITLE
Require the ActiveSupport extensions needed in lib, not test.

### DIFF
--- a/date_validator.gemspec
+++ b/date_validator.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "date_validator"
 
   s.add_runtime_dependency 'activemodel'
+  s.add_runtime_dependency 'activesupport'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'activesupport'
   s.add_development_dependency 'tzinfo'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/active_model/validations/date_validator.rb
+++ b/lib/active_model/validations/date_validator.rb
@@ -1,4 +1,6 @@
 require 'active_model/validations'
+require 'active_support/core_ext/date_time/conversions'
+require 'active_support/core_ext/hash/conversions'
 
 # ActiveModel Rails module.
 module ActiveModel

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,6 @@ begin; require 'turn'; rescue LoadError; end
 gem 'minitest'
 require 'minitest/autorun'
 
-require 'active_support/all'
 require 'active_model'
 require 'date_validator'
 


### PR DESCRIPTION
Rather than requiring the extensions in the tests, we can just require what we
need in the place we need it.

New tests aren't needed - the original tests were passing because necessary
dependencies were loaded in the test_helper rather than in the runtime code.

Without this you can't use the date_validator gem unless you're already loading
ActiveSupport in your project.