### PR TITLE
fix i18n load path

### DIFF
--- a/lib/date_validator/engine.rb
+++ b/lib/date_validator/engine.rb
@@ -1,5 +1,6 @@
 module DateValidator
   class Engine < Rails::Engine
-    paths["config/locales"] = 'locales'
+    files = Dir[Pathname.new(File.dirname(__FILE__)).join('../..', 'locales', '*.yml')]
+    config.i18n.load_path += files
   end
 end


### PR DESCRIPTION
current version occurs
```
I18n::UnknownFileType:
       can not load translations from /(...snip...)/gems/date_validator-0.8.0/locales, the file type  is not known
```
when using with rails.

and
$ rails console
```
> Rails.application.config.i18n[:load_path]
=> ["...../gems/date_validator-0.8.0/locales",
 "...../gems/devise-3.5.1/config/locales/en.yml",
 "...../gems/kaminari-0.16.3/config/locales/kaminari.yml",
 "...../application/config/locales/devise.en.yml",
 "...../application//config/locales/devise.ja.yml",
 "...../application/config/locales/en.yml",
:
:
```