### PR TITLE
Initialize Rails engine with initializer (fix for locales issue)

### DIFF
--- a/lib/date_validator/engine.rb
+++ b/lib/date_validator/engine.rb
@@ -1,6 +1,8 @@
 module DateValidator
   class Engine < Rails::Engine
-    files = Dir[Pathname.new(File.dirname(__FILE__)).join('../..', 'locales', '*.yml')]
-    config.i18n.load_path += files
+    initializer 'date_validator' do
+      files = Dir[Pathname.new(File.dirname(__FILE__)).join('../..', 'locales', '*.yml')]
+      config.i18n.load_path += files
+    end
   end
 end


### PR DESCRIPTION
```ruby
files = Dir[Pathname.new(File.dirname(__FILE__)).join('../..', 'locales', '*.yml')]
config.i18n.load_path += files
```
should execute after Rails initializes itself. Otherise Rails overwrites `config.i18n.load_path` and date_validator locale files are lost.

This PR fixes this issue