### PR TITLE
Added test visualizing interference on numericality equality test

### DIFF
--- a/test/date_validator_test.rb
+++ b/test/date_validator_test.rb
@@ -155,6 +155,14 @@ module ActiveModel
           TestRecord.new('not a date').valid?.must_equal false
         end
       end
+
+      describe "with other validators" do
+        it "does not interfere with numericality equals" do
+          TestRecord.validates_numericality_of :expiration_date, equal_to: 0
+          TestRecord.new(0).valid?.must_equal true
+          TestRecord.new(1).valid?.must_equal false
+        end
+      end
     end
 
   end


### PR DESCRIPTION
DateValidator currently interferes with active models `validates_numericality_of equal_to` validator.

```
 1) Error:
ActiveModel::Validations::DateValidator::with other validators#test_0001_does not interfere with numericality equals:
I18n::MissingInterpolationArgument: missing interpolation argument :date in "must be equal to %{date}" ({:model=>"Test record", :attribute=>"Expiration date", :value=>1.0, :count=>0} given)
```

Might be other similar conflicts, but this is the one i ran into. 