### PR TITLE
Spread keyword args to support Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7]
-        activemodel: [3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0]
+        activemodel: [3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1]
         exclude:
           - ruby: 2.2
             activemodel: 6.0
@@ -26,6 +26,12 @@ jobs:
             activemodel: 6.0
           - ruby: 2.4
             activemodel: 6.0
+          - ruby: 2.2
+            activemodel: 6.1
+          - ruby: 2.3
+            activemodel: 6.1
+          - ruby: 2.4
+            activemodel: 6.1
       fail-fast: true
     env:
       ACTIVE_MODEL_VERSION: ${{ matrix.activemodel }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       matrix:
         ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7]
         activemodel: [3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1]
+        include:
+          - ruby: 3.0
+            activemodel: 6.0
+          - ruby: 3.0
+            activemodel: 6.1
         exclude:
           - ruby: 2.2
             activemodel: 6.0

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,3 @@ active_model_opts =
   end
 
 gem 'activemodel', active_model_opts
-
-platforms :rbx do
-  gem 'rubysl', '~> 2.0'
-end

--- a/lib/active_model/validations/date_validator.rb
+++ b/lib/active_model/validations/date_validator.rb
@@ -59,19 +59,19 @@ module ActiveModel
         end
 
         if value_before_type_cast.present? && value.nil?
-          record.errors.add(attr_name, :not_a_date, options)
+          record.errors.add(attr_name, :not_a_date, **options)
           return
         end
 
         return if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
 
         unless value
-          record.errors.add(attr_name, :not_a_date, options)
+          record.errors.add(attr_name, :not_a_date, **options)
           return
         end
 
         unless is_time?(value)
-          record.errors.add(attr_name, :not_a_date, options)
+          record.errors.add(attr_name, :not_a_date, **options)
           return
         end
 
@@ -94,7 +94,7 @@ module ActiveModel
           end
 
           unless is_time?(option_value) && value.to_i.send(CHECKS[option], option_value.to_i)
-            record.errors.add(attr_name, :"date_#{option}", options.merge(
+            record.errors.add(attr_name, :"date_#{option}", **options.merge(
                 value: original_value,
                 date:  (I18n.localize(original_option_value) rescue original_option_value)
             ))


### PR DESCRIPTION
## ✍️ Description

As of Rails 6.1, `ActiveRecord::Errors.add` spreads keyword arguments rather than accepting an options hash (https://api.rubyonrails.org/v6.1.0/classes/ActiveModel/Errors.html#method-i-add).

In Ruby 3, there is no implicit cast between a last hash argument and explicit keyword arguments, causing argument errors:

```
     ArgumentError:
       wrong number of arguments (given 3, expected 1..2)
     # ./vendor/bundle/ruby/3.0.0/gems/activemodel-6.1.0.rc2/lib/active_model/errors.rb:404:in `add'
     # ./vendor/bundle/ruby/3.0.0/gems/date_validator-0.10.0/lib/active_model/validations/date_validator.rb:97:in `block in validate_each'
```

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.
