### PR TITLE
Fix test flakes

### DIFF
--- a/test/date_validator_test.rb
+++ b/test/date_validator_test.rb
@@ -84,6 +84,8 @@ module ActiveModel
 
             it "allows custom validation message to be handled by I18n" do
               custom_message = 'Custom Date Message'
+
+              I18n.backend.eager_load! if I18n.backend.respond_to?(:eager_load!)
               I18n.backend.store_translations('en', { errors: { messages: { not_a_date: custom_message }}})
 
               TestRecord.validates :expiration_date, date: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ gem 'minitest'
 require 'minitest/autorun'
 
 require 'active_model'
+require 'active_support/core_ext/time/zones'
 require 'date_validator'
 
 I18n.load_path += Dir[File.expand_path(File.join(File.dirname(__FILE__), '../config/locales', '*.yml')).to_s]


### PR DESCRIPTION
## ✍️ Description

The current test suite is order dependent. Specifically, the following test fails if it is not run in the correct order:

```
ActiveModel::Validations::DateValidator::when value does not match validation requirements#test_0012_allows custom validation message to be handled by I18n [/home/runner/work/date_validator/date_validator/test/date_validator_test.rb:93]
```

The cause of this seems to be related to lazy loading of translations by the I18n gem.

If `I18n.backend.store_translations` is called before the I18n backend has loaded translations, the "overridden" translation is lost and the default is returned instead. This would only be an issue for ActiveModel versions depending on `i18n >= 1.6.0`, which appears to have only been required since Rails 6.

Also pulls in 4df94311284af408007696f57638d1f88efff390 to fix issues if `Time.zone` hasn't been required yet.

## ✅ Fixes

This should fix the flakes currently blocking https://github.com/codegram/date_validator/pull/85

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## Documentation

I18n release notes for lazy/eager loading: https://github.com/ruby-i18n/i18n/releases/tag/v1.6.0