### PR TITLE
Handle attribute i18n gender

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,7 +5,7 @@ fr:
   errors:
     messages:
       not_a_date: "n'est pas une date"
-      date_after: "doit être après %{date}"
-      date_after_or_equal_to: "doit être supérieur(e) ou égal à %{date}"
-      date_before: "doit être avant %{date}"
-      date_before_or_equal_to: "doit être inférieur(e) ou égal à %{date}"
+      date_after: "doit être après le %{date}"
+      date_after_or_equal_to: "doit être supérieur(e) ou égal(e) à %{date}"
+      date_before: "doit être avant le %{date}"
+      date_before_or_equal_to: "doit être inférieur(e) ou égal(e) à %{date}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -6,6 +6,6 @@ fr:
     messages:
       not_a_date: "n'est pas une date"
       date_after: "doit être après %{date}"
-      date_after_or_equal_to: "doit être supérieur ou égal à %{date}"
+      date_after_or_equal_to: "doit être supérieur(e) ou égal à %{date}"
       date_before: "doit être avant %{date}"
-      date_before_or_equal_to: "doit être inférieur ou égal à %{date}"
+      date_before_or_equal_to: "doit être inférieur(e) ou égal à %{date}"


### PR DESCRIPTION
In French, a date is a feminine noun and chances are that the name of the validated attribute contains _date.

In this case, the correct translation for below keys are :

`date_after_or_equal_to: "doit être supérieure ou égal à %{date}"`

`date_before_or_equal_to: "doit être inférieure ou égal à %{date}"`

