### PR TITLE
don't use .to_i to avoid different usec being considered equal

### DIFF
--- a/lib/active_model/validations/date_validator.rb
+++ b/lib/active_model/validations/date_validator.rb
@@ -93,7 +93,7 @@ module ActiveModel
             value = value.to_datetime if value.is_a?(Date)
           end
 
-          unless is_time?(option_value) && value.to_i.send(CHECKS[option], option_value.to_i)
+          unless is_time?(option_value) && value.send(CHECKS[option], option_value)
             record.errors.add(attr_name, :"date_#{option}", **options.merge(
                 value: original_value,
                 date:  (I18n.localize(original_option_value) rescue original_option_value)

--- a/test/date_validator_test.rb
+++ b/test/date_validator_test.rb
@@ -39,14 +39,14 @@ module ActiveModel
 
         describe _context do
           [:after, :before, :after_or_equal_to, :before_or_equal_to, :equal_to].each do |check|
-              now = Time.now.to_datetime
+              now = Time.now.to_datetime.change(usec: 0)
 
               model_date = case check
                 when :after              then must_be == :valid ? now + 21000 : now - 1
                 when :before             then must_be == :valid ? now - 21000 : now + 1
                 when :after_or_equal_to  then must_be == :valid ? now : now - 21000
                 when :before_or_equal_to then must_be == :valid ? now : now + 21000
-                when :equal_to           then must_be == :valid ? now : now + 21000
+                when :equal_to           then must_be == :valid ? now : now.change(usec: 1)
               end
 
               it "ensures that an attribute is #{must_be} when #{must_be == :valid ? 'respecting' : 'offending' } the #{check} check" do


### PR DESCRIPTION
## ✍️ Description

(required) Please include any relevant details about this Pull Request, with a focus on:

- _What_ does it fix.
Different times being considered equal.

```ruby
ApplicationRecord.connection.execute("CREATE TABLE models (id UUID, my_date TIMESTAMP)")

class Model < ApplicationRecord
  validates :my_date, date: { equal_to: ->(model) { model.my_date.end_of_day } }
end

model = Model.new
model.my_date = Time.current.end_of_day.change(usec: 0)
model.valid? # true
model.my_date == model.my_date.end_of_day # false
```

- _Why_ did you do things this way.
The previous implementation used .to_i to compare dates, this lead to a bug where a model would pass validation without actually being valid.

- _How_ does it fix the issue at hand.
Just changed the implementation to compare dates without .to_i

Based on the test suite, it looks fine.